### PR TITLE
Enable production infrastructure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,31 +6,56 @@ include:
  
 # These variables are available for all stages
 variables:
-  SERVICE_PORT: "3000"
-  K8S_PORT: "3000"
- 
-# Build stage must be included and it must extend .build.
-build:
-  extends: .build
- 
-review:
+  SERVICE_PORT: 3000
+  K8S_PORT: 3000
+
+build-review:
   # These variables are available only for review env and are merged with the general variables defined above.
+  extends: .build
+  # Build time variables
   variables:
-    POSTGRES_ENABLED: 0
+    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
   only:
     refs:
       - external_pull_requests
 
+build-staging:
+  extends: .build
+  # Build time variables
+  variables:
+    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
+  only:
+    refs:
+      - develop
+
+build-production:
+  extends: .build
+  # Build time variables
+  variables:
+    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"
+  only:
+    refs:
+      - master
+      # this regexp will match release-tags
+      - /^release-.*$/
+ 
+review:
+  # Runtime variables
+  variables:
+    POSTGRES_ENABLED: 0
+    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
+
 staging:
+  # Runtime variables
+  variables:
+    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
   # By default the staging environment is created from the master-branch.
   # Here we define that it should be created from the branch called "develop" instead.
   only:
     refs:
       - develop
-  # These variables are available only for staging env and are merged with the general variables defined above.
-  # variables:
 
-# No production build for now
-# production:
-  # These variables are available only for production env and are merged with the general variables defined above.
-  # variables:
+production:
+  # Runtime variables
+  variables:
+    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"


### PR DESCRIPTION
These changes toggle on the production infrastructure. After these changes, new releases in the master branch should start a production deploy. Releases should be tagged like so: `release-*`.